### PR TITLE
Prevent text glitch if a pokemon has an unspecified custom evolution

### DIFF
--- a/include/strings.h
+++ b/include/strings.h
@@ -638,6 +638,7 @@ extern const u8 gText_EVO_SPECIFIC_MON_IN_PARTY[];
 extern const u8 gText_EVO_LEVEL_DARK_TYPE_MON_IN_PARTY[];
 extern const u8 gText_EVO_TRADE_SPECIFIC_MON[];
 extern const u8 gText_EVO_SPECIFIC_MAP[];
+extern const u8 gText_EVO_UNKNOWN[];
 extern const u8 gText_EVO_NONE[];
 
 extern const u8 gText_FORMS_Buttons_PE[];

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -7771,6 +7771,9 @@ static u8 PrintEvolutionTargetSpeciesAndMethod(u8 taskId, u16 species, u8 depth,
                 StringExpandPlaceholders(gStringVar4, gText_EVO_SPECIFIC_MAP );
                 break;
         #endif
+        default:
+            StringExpandPlaceholders(gStringVar4, gText_EVO_UNKNOWN );
+            break;
         }//Switch end
         PrintInfoScreenTextSmall(gStringVar4, base_x + depth_x*depth+base_x_offset, base_y + base_y_offset*base_i); //Print actual instructions
 

--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -387,10 +387,10 @@ static void Task_SwitchScreensFromFormsScreen(u8 taskId);
 static void Task_ExitFormsScreen(u8 taskId);
 #endif
 
-//COMPATIBILITY, delete if you are using a newer version
+#ifndef TEXT_COLOR_LIGHT_GRAY // COMPATIBILITY
 #define TEXT_COLOR_LIGHT_GRAY TEXT_COLOR_LIGHT_GREY
 #define TEXT_COLOR_DARK_GRAY TEXT_COLOR_DARK_GREY
-//COMPATIBILITY end
+#endif
 
 //HGSS_UI Physical Special Split icon for BattleEngine (rhh)
 #ifdef BATTLE_ENGINE

--- a/src/strings.c
+++ b/src/strings.c
@@ -1924,6 +1924,7 @@ const u8 gText_EVO_SPECIFIC_MON_IN_PARTY[]          = _("LvlUp with {STR_VAR_2} 
 const u8 gText_EVO_LEVEL_DARK_TYPE_MON_IN_PARTY[]   = _("LvlUp with dark type in party");
 const u8 gText_EVO_TRADE_SPECIFIC_MON[]             = _("Traded for {STR_VAR_2}");
 const u8 gText_EVO_SPECIFIC_MAP[]                   = _("LvlUp on {STR_VAR_2}");
+const u8 gText_EVO_UNKNOWN[]                        = _("Method unknown");
 const u8 gText_EVO_NONE[]                           = _("{STR_VAR_1} has no evolution.");
 
 const u8 gText_FORMS_Buttons_PE[]                   = _("{A_BUTTON}EVOLUTIONS");


### PR DESCRIPTION
If a romhack defines a new Evolution method, but doesn't define a string in the switch statement, it'll just use the last string loaded (likely a Move Description)

This adds a default message.