### PR TITLE
#include pokemon.h in src/pokedex.c

### DIFF
--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -28,6 +28,7 @@
 #include "pokemon_summary_screen.h"
 #ifdef POKEMON_EXPANSION
 #include "region_map.h"
+#include "pokemon.h"
 #endif
 #include "reset_rtc_screen.h"
 #include "scanline_effect.h"


### PR DESCRIPTION
## Description
Your custom Pokédex makes use of `gFormSpeciesIdTables` which is defined in `include/pokemon.h` inside the pokemon_expansion branch of the Pokeemerald-expansion.
Yet, you forgot to let the `src/pokedex.c` file read the contents from that file.
This PR fixes it.

## **Discord contact info**
Lunos#4026