### PR TITLE
Update debug.c

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -276,7 +276,11 @@ extern u8 Debug_ShowFieldMessageStringVar4[];
 extern u8 Debug_CheatStart[];
 extern u8 PlayersHouse_2F_EventScript_SetWallClock[];
 extern u8 PlayersHouse_2F_EventScript_CheckWallClock[];
+#ifdef BATTLE_ENGINE
+#define ABILITY_NAME_LENGTH 16
+#else
 #define ABILITY_NAME_LENGTH 12
+#endif
 extern const u8 gAbilityNames[][ABILITY_NAME_LENGTH + 1];
 
 


### PR DESCRIPTION
## Description
Some time ago, the length of the ability names was expanded from 12 to 16 in the Pokeemerald-expansion's battle_engine.
This PR corrects its re-definition of the label so ability names can show up normally on certain debug features such as "Give Pokémon (Advanced)" for projects that use said branch.

## **Discord contact info**
Lunos#4026