### PR TITLE
Fixed dex showing incorrect moves when using PE and BE

### DIFF
--- a/src/pokedex.c
+++ b/src/pokedex.c
@@ -5277,7 +5277,7 @@ bool8  SpeciesCanLearnLvlUpMove(u16 species, u16 move) //Move search PokedexPlus
     #if defined (BATTLE_ENGINE) || defined (POKEMON_EXPANSION)
         for (j = 0; j < MAX_LEVEL_UP_MOVES && gLevelUpLearnsets[species][j].move != LEVEL_UP_END; j++)
         {
-            if (move == (gLevelUpLearnsets[species][j].move & LEVEL_UP_MOVE_ID))
+            if (move == (gLevelUpLearnsets[species][j].move))
             {
                 return TRUE;
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I had accidentally left `LEVEL_UP_MOVE_ID` in `SpeciesCanLearnLvlUpMove` when using Pokémon Expansion and Battle Engine

## **Discord contact info**
AsparagusEduardo#6051