### PR TITLE
Set gIsDebugBattle to FALSE after battle

### DIFF
--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -46,6 +46,7 @@
 #include "constants/trainers.h"
 #include "constants/trainer_hill.h"
 #include "constants/weather.h"
+#include "debug.h"
 
 enum {
     TRANSITION_TYPE_NORMAL,
@@ -1392,6 +1393,9 @@ void BattleSetup_StartTrainerBattle_Debug(void)
 
 static void CB2_EndTrainerBattle(void)
 {
+    #if TX_DEBUG_SYSTEM_ENABLE == TRUE
+        gIsDebugBattle = FALSE;
+    #endif
     if (gTrainerBattleOpponent_A == TRAINER_SECRET_BASE)
     {
         SetMainCallback2(CB2_ReturnToFieldContinueScriptPlayMapMusic);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Hello, I was trying your debug menu and its new features since the last time I had pulled from it, which has been very useful in development. I was using the battle test option to create a wild battle with a Bulbasaur, but then I noticed some buggy behaviour where all other trainer battles would be against the same Bulbasaur and terrain. I believe this is because gIsDebugBattle is never set to FALSE after starting the debug battle which causes all other battles to load the saved party, so I tried adding a check in battle_setup.c to set it to FALSE in the callback after the battle ends if that is fine.
## **Discord contact info**

Flame#9168
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->